### PR TITLE
Fix allowedMethods typo

### DIFF
--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -3,8 +3,8 @@ import { resolve } from "node:path";
 import database from "infra/database.js";
 
 export default async function migrations(request, response) {
-  const allwedMethods = ["GET", "POST"];
-  if (!allwedMethods.includes(request.method)) {
+  const allowedMethods = ["GET", "POST"];
+  if (!allowedMethods.includes(request.method)) {
     return response.status(405).json({
       error: `Method "${request.method}" not allowed`,
     });


### PR DESCRIPTION
## Summary
- rename `allwedMethods` to `allowedMethods` in migrations API

## Testing
- `npm run lint:eslint:check` *(fails: next not found)*
- `npm test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fa1dc1108322979432a5c4874b10